### PR TITLE
Disable the busylight module

### DIFF
--- a/mimikatz/mimikatz.c
+++ b/mimikatz/mimikatz.c
@@ -24,7 +24,7 @@ const KUHL_M * mimikatz_modules[] = {
 	&kuhl_m_net,
 #endif
 	&kuhl_m_dpapi,
-	&kuhl_m_busylight,
+	//&kuhl_m_busylight,
 	&kuhl_m_sysenv,
 	&kuhl_m_sid,
 	&kuhl_m_iis,


### PR DESCRIPTION
I learned something today that I should have learned a while ago! That is, mimikatz has a module baked in that lights up a busylight device if there's one attached to the machine it's running on.

I was so focussed on getting mimikatz working in Meterpreter that I didn't look into the code to see what kind if things it brought with it. Yup, I'm lame. Sorry!

This PR removes the busylight module entry from the module list, and so this prevents it from being used. This means that when the kiwi extension loads in future, it won't light up any attached busylights!

When landed, I'll get this merged over to the Meterp source.