### PR TITLE
fix mingw x86 build error

### DIFF
--- a/modules/rpc/kull_m_rpc.c
+++ b/modules/rpc/kull_m_rpc.c
@@ -234,11 +234,7 @@ void kull_m_rpc_getArgs(int argc, wchar_t * argv[], LPCWSTR *szRemote, LPCWSTR *
 	}
 }
 
-#ifdef __MINGW32__
-void __RPC_FAR* __RPC_USER MIDL_user_allocate(SIZE_T cBytes)
-#else
 void __RPC_FAR* __RPC_USER MIDL_user_allocate(size_t cBytes)
-#endif
 {
 	return LocalAlloc(LPTR, cBytes);
 }


### PR DESCRIPTION
This appears to fix the x86 build of meterpreter on mingw.
You will first need to land the fix in https://github.com/rapid7/metasploit-payloads/pull/493 to uncover this issue.

## Verification
```
cd metasploit-payloads/c/meterpreter
make meterpreter-x86 # x64 builds fine already
...
metasploit-payloads/c/meterpreter/source/extensions/kiwi/mimikatz/modules/rpc/kull_m_rpc.c: At top level:
metasploit-payloads/c/meterpreter/source/extensions/kiwi/mimikatz/modules/rpc/kull_m_rpc.c:238:28: error: conflicting types for ‘MIDL_user_allocate’
  238 | void __RPC_FAR* __RPC_USER MIDL_user_allocate(SIZE_T cBytes)

```

## After
```
cd metasploit-payloads/c/meterpreter
make meterpreter-x86 # x64 builds fine already
...
[ 59%] Linking C shared library ext_server_kiwi.x86.dll
```