### PR TITLE
bugfix machine masterkey decryption

### DIFF
--- a/mimikatz/modules/dpapi/kuhl_m_dpapi.c
+++ b/mimikatz/modules/dpapi/kuhl_m_dpapi.c
@@ -238,8 +238,7 @@ NTSTATUS kuhl_m_dpapi_masterkey(int argc, wchar_t * argv[])
 							if((cbSystem - cbSystemOffset) == 2 * SHA_DIGEST_LENGTH)
 							{
 								kprintf(L"\n[masterkey] with DPAPI_SYSTEM (machine, then user): "); kull_m_string_wprintf_hex(pSystem + cbSystemOffset, 2 * SHA_DIGEST_LENGTH, 0); kprintf(L"\n");
-								if(kull_m_dpapi_unprotect_masterkey_with_userHash(masterkeys->MasterKey, pSystem + cbSystemOffset, SHA_DIGEST_LENGTH, convertedSid, isProtected, &output, &cbOutput))
-
+								if(kull_m_dpapi_unprotect_masterkey_with_shaDerivedkey(masterkeys->MasterKey, pSystem + cbSystemOffset, SHA_DIGEST_LENGTH, &output, &cbOutput))
 								{
 									kprintf(L"** MACHINE **\n");
 									kuhl_m_dpapi_display_MasterkeyInfosAndFree(statusGuid ? &guid : NULL, output, cbOutput, NULL);


### PR DESCRIPTION
This PR fixes machine masterkey decryption command. sample command:
`dpapi::masterkey /in:C:\fake\path\S-1-5-18\e5ed5c9d-be52-4e98-a218-fbafb16344d1 /sid:S-1-5-18 /system:92eceee795c025ddab7d80f1a25ae17f29af177d`

it seems the old line (`kull_m_dpapi_unprotect_masterkey_with_userHash`), is just a copy-paste from [#L247](https://github.com/rapid7/mimikatz/blob/master/mimikatz/modules/dpapi/kuhl_m_dpapi.c#L247) by mistake